### PR TITLE
:wrench:  set up sync of notebooks to py:percent format (manually)

### DIFF
--- a/docs/api_examples/jupytext.toml
+++ b/docs/api_examples/jupytext.toml
@@ -1,0 +1,6 @@
+# all notebooks in this directory are synced percent format when typing
+# (jupytext is a dev dependency)
+# jupytext --sync *.ipynb
+# or from root directory
+# jupytext --sync docs/api_examples/*.ipynb
+formats = "ipynb,py:percent"


### PR DESCRIPTION
Keep both formats in sync manually for now. Could be checked in an action, but it's details.

Here the config is uploaded to make sync calls automaticly working.